### PR TITLE
Wrapping up asynchronous APM pattern to TAP pattern

### DIFF
--- a/WinUSBNet/USBDevice.cs
+++ b/WinUSBNet/USBDevice.cs
@@ -703,10 +703,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlTransferAsync(byte requestType, byte request, int value, int index, byte[] buffer, int length)
         {
-            var asyncResult = this.BeginControlTransfer(requestType, request, value, index, buffer, length, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlTransfer(requestType, request, value, index, buffer, length, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>
@@ -732,10 +743,22 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlTransferAsync(byte requestType, byte request, int value, int index, byte[] buffer)
         {
-            var asyncResult = this.BeginControlTransfer(requestType, request, value, index, buffer, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlTransfer(requestType, request, value, index, buffer, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>
@@ -758,10 +781,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlTransferAsync(byte requestType, byte request, int value, int index)
         {
-            var asyncResult = this.BeginControlTransfer(requestType, request, value, index, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlTransfer(requestType, request, value, index, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>
@@ -782,10 +816,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlInAsync(byte requestType, byte request, int value, int index, byte[] buffer, int length)
         {
-            var asyncResult = this.BeginControlIn(requestType, request, value, index, buffer, length, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlIn(requestType, request, value, index, buffer, length, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>
@@ -805,10 +850,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlInAsync(byte requestType, byte request, int value, int index, byte[] buffer)
         {
-            var asyncResult = this.BeginControlIn(requestType, request, value, index, buffer, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlIn(requestType, request, value, index, buffer, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>
@@ -827,10 +883,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlInAsync(byte requestType, byte request, int value, int index)
         {
-            var asyncResult = this.BeginControlIn(requestType, request, value, index, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlIn(requestType, request, value, index, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>
@@ -851,10 +918,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlOutAsync(byte requestType, byte request, int value, int index, byte[] buffer, int length)
         {
-            var asyncResult = this.BeginControlOut(requestType, request, value, index, buffer, length, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlOut(requestType, request, value, index, buffer, length, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>
@@ -874,10 +952,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlOutAsync(byte requestType, byte request, int value, int index, byte[] buffer)
         {
-            var asyncResult = this.BeginControlOut(requestType, request, value, index, buffer, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlOut(requestType, request, value, index, buffer, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>
@@ -896,10 +985,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ControlOutAsync(byte requestType, byte request, int value, int index)
         {
-            var asyncResult = this.BeginControlOut(requestType, request, value, index, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndControlTransfer);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginControlOut(requestType, request, value, index, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndControlTransfer(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 #endif
 

--- a/WinUSBNet/USBDevice.cs
+++ b/WinUSBNet/USBDevice.cs
@@ -678,6 +678,230 @@ namespace MadWizard.WinUSBNet
             return BeginControlTransfer(requestType, request, value, index, new byte[0], userCallback, stateObject);
         }
 
+#if !NET35
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes IO over the default control endpoint.
+        ///     This method allows both IN and OUT direction transfers, depending on the highest bit of the <paramref name="requestType"/> parameter.
+        ///     Alternatively, <see cref="ControlInAsync(byte,byte,int,int,byte[],int)"/>
+        ///     and <see cref="ControlOutAsync(byte,byte,int,int,byte[],int)"/> can be used for asynchronous control transfers in a specific direction,
+        ///     which is the recommended way because it prevents using the wrong direction accidentally.
+        ///     Use the BeginControlTransfer method when the direction is not known at compile time.
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="buffer">The data to transfer in the data stage of the control. When the transfer is in the IN direction the data received will be
+        /// written to this buffer. For an OUT direction transfer the contents of the buffer are written sent through the pipe. Note: This buffer is not allowed
+        /// to change for the duration of the asynchronous operation.</param>
+        /// <param name="length">Length of the data to transfer. Must be equal to or less than the length of <paramref name="buffer"/>. The setup packet's length member will be set to this length.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous read operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlTransferAsync(byte requestType, byte request, int value, int index, byte[] buffer, int length)
+        {
+            var asyncResult = this.BeginControlTransfer(requestType, request, value, index, buffer, length, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes IO over the default control endpoint.
+        ///     This method allows both IN and OUT direction transfers, depending on the highest bit of the <paramref name="requestType"/> parameter.
+        ///     Alternatively, <see cref="ControlInAsync(byte,byte,int,int,byte[])"/>
+        ///     and <see cref="ControlOutAsync(byte,byte,int,int,byte[])"/> can be used for asynchronous control transfers in a specific direction,
+        ///     which is the recommended way because it prevents using the wrong direction accidentally.
+        ///     Use the BeginControlTransfer method when the direction is not known at compile time.
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="buffer">The data to transfer in the data stage of the control. When the transfer is in the IN direction the data received will be
+        /// written to this buffer. For an OUT direction transfer the contents of the buffer are written sent through the pipe. Note: This buffer is not allowed
+        /// to change for the duration of the asynchronous operation.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous read operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlTransferAsync(byte requestType, byte request, int value, int index, byte[] buffer)
+        {
+            var asyncResult = this.BeginControlTransfer(requestType, request, value, index, buffer, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes IO without a data stage over the default control endpoint.
+        ///     This method allows both IN and OUT direction transfers, depending on the highest bit of the <paramref name="requestType"/> parameter.
+        ///     Alternatively, <see cref="ControlInAsync(byte,byte,int,int)"/>
+        ///     and <see cref="ControlOutAsync(byte,byte,int,int)"/> can be used for asynchronous control transfers in a specific direction,
+        ///     which is the recommended way because it prevents using the wrong direction accidentally.
+        ///     Use the BeginControlTransfer method when the direction is not known at compile time.
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <returns>
+        ///     A task that represents the asynchronous read operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlTransferAsync(byte requestType, byte request, int value, int index)
+        {
+            var asyncResult = this.BeginControlTransfer(requestType, request, value, index, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes input operation over the default control endpoint.
+        ///     The request should have an IN direction (specified by the highest bit of the <paramref name="requestType"/> parameter).
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="buffer">The buffer that will receive the data transfered.</param>
+        /// <param name="length">Length of the data to transfer. Must be equal to or less than the length of <paramref name="buffer"/>. The setup packet's length member will be set to this length.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous input operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlInAsync(byte requestType, byte request, int value, int index, byte[] buffer, int length)
+        {
+            var asyncResult = this.BeginControlIn(requestType, request, value, index, buffer, length, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes input operation over the default control endpoint.
+        ///     The request should have an IN direction (specified by the highest bit of the <paramref name="requestType"/> parameter).
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="buffer">The buffer that will receive the data transfered.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous input operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlInAsync(byte requestType, byte request, int value, int index, byte[] buffer)
+        {
+            var asyncResult = this.BeginControlIn(requestType, request, value, index, buffer, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes input operation without a data stage over the default control endpoint.
+        ///     The request should have an IN direction (specified by the highest bit of the <paramref name="requestType"/> parameter).
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <returns>
+        ///     A task that represents the asynchronous input operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlInAsync(byte requestType, byte request, int value, int index)
+        {
+            var asyncResult = this.BeginControlIn(requestType, request, value, index, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes output operation over the default control endpoint.
+        ///     The request should have an OUT direction (specified by the highest bit of the <paramref name="requestType"/> parameter).
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="buffer">The buffer that contains the data to be transfered.</param>
+        /// <param name="length">Length of the data to transfer. Must be equal to or less than the length of <paramref name="buffer"/>. The setup packet's length member will be set to this length.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous output operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlOutAsync(byte requestType, byte request, int value, int index, byte[] buffer, int length)
+        {
+            var asyncResult = this.BeginControlOut(requestType, request, value, index, buffer, length, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes output operation over the default control endpoint.
+        ///     The request should have an OUT direction (specified by the highest bit of the <paramref name="requestType"/> parameter).
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="buffer">The buffer that contains the data to be transfered.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous output operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlOutAsync(byte requestType, byte request, int value, int index, byte[] buffer)
+        {
+            var asyncResult = this.BeginControlOut(requestType, request, value, index, buffer, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+
+        /// <summary>
+        ///     Asynchronously issue a sequence of bytes output operation without a data stage over the default control endpoint.
+        ///     The request should have an OUT direction (specified by the highest bit of the <paramref name="requestType"/> parameter).
+        /// </summary>
+        /// <param name="requestType">The setup packet request type.</param>
+        /// <param name="request">The setup packet device request.</param>
+        /// <param name="value">The value member in the setup packet. Its meaning depends on the request. Value should be between zero and 65535 (0xFFFF).</param>
+        /// <param name="index">The index member in the setup packet. Its meaning depends on the request. Index should be between zero and 65535 (0xFFFF).</param>
+        /// <returns>
+        ///     A task that represents the asynchronous output operation.
+        ///     The value of the TResult parameter contains the total number of bytes that has been transferred.
+        ///     The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number,
+        ///     or it can be 0 (zero) if the end of the stream has been reached.
+        /// </returns>
+        public System.Threading.Tasks.Task<int> ControlOutAsync(byte requestType, byte request, int value, int index)
+        {
+            var asyncResult = this.BeginControlOut(requestType, request, value, index, null, null);
+            return System.Threading.Tasks.Task<int>
+                                         .Factory
+                                         .FromAsync(asyncResult, this.EndControlTransfer);
+        }
+#endif
 
         private void CheckNotDisposed()
         {

--- a/WinUSBNet/USBPipe.cs
+++ b/WinUSBNet/USBPipe.cs
@@ -341,10 +341,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int length)
         {
-            var asyncResult = this.BeginRead(buffer, offset, length, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndRead);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginRead(buffer, offset, length, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndRead(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 
         /// <summary>Asynchronously write a sequence of bytes from the USB pipe.</summary>
@@ -359,10 +370,21 @@ namespace MadWizard.WinUSBNet
         /// </returns>
         public System.Threading.Tasks.Task<int> WriteAsync(byte[] buffer, int offset, int length)
         {
-            var asyncResult = this.BeginWrite(buffer, offset, length, null, null);
-            return System.Threading.Tasks.Task<int>
-                                         .Factory
-                                         .FromAsync(asyncResult, this.EndWrite);
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<int>();
+
+            this.BeginWrite(buffer, offset, length, (iar) =>
+            {
+                try
+                {
+                    tcs.TrySetResult(this.EndWrite(iar));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }, null);
+
+            return tcs.Task;
         }
 #endif
 


### PR DESCRIPTION
# Sample usage

```cs
static async Task Main(string[] args)
{
    USBDevice device = USBDevice.GetSingleDevice("{BB9176E8-924F-4a7e-963A-6DC6A4E87FC2}");
    USBPipe pipe = device.Pipes[0x81];

    byte[] writeBuffer = new byte[1] { 0x00 };
    byte[] readBuffer = new byte[1024];

    await device.ControlOutAsync(0x0, 0x0, 0x0, 0x0, writeBuffer, 1);
    await pipe.ReadAsync(readBuffer, 0, 1)

    await Task.Delay(Timeout.Infinite);
}
```

# Cancellation

In general, async function passes a `CancellationToken` as function argument. Use this token to stop asynchronous task. But Winusb APIs has a `USBPipe.Abort` which doing the same work. In order not to be confused , the async functions does not include CancellationToken as argument.

# Summary modifications
- Add TPL style APIs
    - For USBDevice:
        - ControlTransferAsync
        - ControlInAsync
        - ControlOutAsync
    - For USBPipe:
        - ReadAsync
        - WriteAsync
- Modify the EndWrite return type of USBPipe, it return BytesTransfered count.

# References
- [Interop with Other Asynchronous Patterns and Types](https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/interop-with-other-asynchronous-patterns-and-types)
- [TaskFactory.FromAsync Method](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskfactory.fromasync?view=net-5.0)
- [Asynchronous programming with async and await](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/async/)